### PR TITLE
ARGO-3136 Update check web api probe to ignore disabled reports

### DIFF
--- a/modules/web_api.py
+++ b/modules/web_api.py
@@ -85,6 +85,10 @@ def createAPICallUrl(arguments):
                                                        errmsg_from_excp(e))
         raise SystemExit(2)
 
+    # Remove disabled reports from response's data results
+    profilesjson["data"] = [ x for x in profilesjson["data"] if x["disabled"] == False ]
+
+
     return profilesjson
 
 


### PR DESCRIPTION
When testing web-api for results, ignore disabled reports. Disable reports are designated by the json key/value `"disabled": true`